### PR TITLE
Add daily Cella statistics loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,24 @@
 
 Utility to load daily Cella statistics into PostgreSQL.
 
+The script reads configuration from environment variables and requires no
+command-line options. Set the variables and run the script:
+
 ```
-python load_cella_stats_daily.py \
-    --cella Cella613 \
-    --partial "Частично.xls" \
-    --full "Целиком.xls" \
-    --forecast "Почасовой прогноз прихода заказов на склад.csv" \
-    --host 192.168.3.19 --port 5432 --dbname postgres \
-    --user Admin --password 0782 \
-    --schema REPORT --table "execution-of-orders"
+export CELLA=Cella613
+export PARTIAL_XLS="Частично.xls"
+export FULL_XLS="Целиком.xls"
+export FORECAST_CSV="Почасовой прогноз прихода заказов на склад.csv"
+export PGHOST=192.168.3.19
+export PGPORT=5432
+export PGDATABASE=postgres
+export PGUSER=Admin
+export PGPASSWORD=0782
+export SCHEMA=REPORT
+export TABLE="execution-of-orders"
+
+python load_cella_stats_daily.py
 ```
 
-Run without arguments to see the full list of supported options.
+File paths default to the names shown above if the corresponding environment
+variables are not set.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ pip install -r requirements.txt
 ```
 
 All configuration values such as file locations and database credentials are
-hard coded in ``load_cella_stats_daily.py``. To run the loader simply execute:
+hard coded in ``load_cella_stats_daily.py``. The script scans all three reports,
+combines the union of Cellas found and stores row counts from the two XLS files
+along with the "Ожидается" value from the forecast CSV (looked up by the
+``cella`` column). Missing pieces for a Cella are written as SQL ``NULL``.
+
+To run the loader simply execute:
 
 ```
 python load_cella_stats_daily.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # execution-of-orders
+
+Utility to load daily Cella statistics into PostgreSQL.
+
+```
+python load_cella_stats_daily.py \
+    --cella Cella613 \
+    --partial "Частично.xls" \
+    --full "Целиком.xls" \
+    --forecast "Почасовой прогноз прихода заказов на склад.csv" \
+    --host 192.168.3.19 --port 5432 --dbname postgres \
+    --user Admin --password 0782 \
+    --schema REPORT --table "execution-of-orders"
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The script reads configuration from environment variables and requires no
 command-line options. Set the variables and run the script:
 
 ```
+export DATA_DIR="//192.168.3.7/ul/Закупки/DATA"
 export PARTIAL_XLS="Частично.xls"
 export FULL_XLS="Целиком.xls"
 export FORECAST_CSV="Почасовой прогноз прихода заказов на склад.csv"
@@ -30,5 +31,6 @@ By default, statistics are loaded for all Cellas found in the reports. To limit
 processing to a single Cella, set the ``CELLA`` environment variable before
 running the script.
 
-File paths default to the names shown above if the corresponding environment
-variables are not set.
+If ``DATA_DIR`` is omitted, the script looks for files in the current
+directory. Individual file variables (``PARTIAL_XLS`` etc.) may also be
+overridden with absolute paths.

--- a/README.md
+++ b/README.md
@@ -8,29 +8,12 @@ Install dependencies first:
 pip install -r requirements.txt
 ```
 
-The script reads configuration from environment variables and requires no
-command-line options. Set the variables and run the script:
+All configuration values such as file locations and database credentials are
+hard coded in ``load_cella_stats_daily.py``. To run the loader simply execute:
 
 ```
-export DATA_DIR="//192.168.3.7/ul/Закупки/DATA"
-export PARTIAL_XLS="Частично.xls"
-export FULL_XLS="Целиком.xls"
-export FORECAST_CSV="Почасовой прогноз прихода заказов на склад.csv"
-export PGHOST=192.168.3.19
-export PGPORT=5432
-export PGDATABASE=postgres
-export PGUSER=Admin
-export PGPASSWORD=0782
-export SCHEMA=REPORT
-export TABLE="execution-of-orders"
-
 python load_cella_stats_daily.py
 ```
 
-By default, statistics are loaded for all Cellas found in the reports. To limit
-processing to a single Cella, set the ``CELLA`` environment variable before
-running the script.
-
-If ``DATA_DIR`` is omitted, the script looks for files in the current
-directory. Individual file variables (``PARTIAL_XLS`` etc.) may also be
-overridden with absolute paths.
+To change paths or connection settings, edit the constants at the top of the
+script.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The script reads configuration from environment variables and requires no
 command-line options. Set the variables and run the script:
 
 ```
-export CELLA=Cella613
 export PARTIAL_XLS="Частично.xls"
 export FULL_XLS="Целиком.xls"
 export FORECAST_CSV="Почасовой прогноз прихода заказов на склад.csv"
@@ -20,6 +19,10 @@ export TABLE="execution-of-orders"
 
 python load_cella_stats_daily.py
 ```
+
+By default, statistics are loaded for all Cellas found in the reports. To limit
+processing to a single Cella, set the ``CELLA`` environment variable before
+running the script.
 
 File paths default to the names shown above if the corresponding environment
 variables are not set.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Utility to load daily Cella statistics into PostgreSQL.
 
+Install dependencies first:
+
+```
+pip install -r requirements.txt
+```
+
 The script reads configuration from environment variables and requires no
 command-line options. Set the variables and run the script:
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ python load_cella_stats_daily.py
 
 To change paths or connection settings, edit the constants at the top of the
 script.
+
+The loader ensures the target table exists with the following structure:
+
+```
+REPORT."execution-of-orders" (
+    id BIGSERIAL PRIMARY KEY,
+    stats_date DATE NOT NULL,
+    cella TEXT NOT NULL,
+    partial_count INT,
+    full_count INT,
+    expected NUMERIC(18,2),
+    UNIQUE (cella, stats_date)
+)
+```

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ python load_cella_stats_daily.py \
     --user Admin --password 0782 \
     --schema REPORT --table "execution-of-orders"
 ```
+
+Run without arguments to see the full list of supported options.

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -100,7 +100,9 @@ def count_xls_rows(
         ) from exc
     if cella:
         df = df[df[cella_col] == cella]
-    df[date_col] = pd.to_datetime(df[date_col], errors="coerce").dt.date
+    # Dates in the reports use day-first formatting (e.g. 26.08.2025),
+    # so explicitly enable dayfirst parsing to avoid ambiguous warnings.
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce", dayfirst=True).dt.date
     df = df[df[date_col] == stats_date]
     return df.groupby(cella_col).size()
 

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -68,7 +68,12 @@ def count_xls_rows(
     path: str, date_col: str, cella_col: str, stats_date: date, cella: Optional[str]
 ) -> pd.Series:
     """Count rows in an XLS file for the given date grouped by Cella."""
-    df = pd.read_excel(path, engine="xlrd")
+    try:
+        df = pd.read_excel(path, engine="xlrd")
+    except ImportError as exc:  # pragma: no cover - dependency check
+        raise SystemExit(
+            "Missing optional dependency 'xlrd'. Install it with 'pip install xlrd'."
+        ) from exc
     if cella:
         df = df[df[cella_col] == cella]
     df[date_col] = pd.to_datetime(df[date_col], errors="coerce").dt.date

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Optional
@@ -173,6 +174,13 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--tz", default="Europe/Moscow", help="Timezone for date calculations"
     )
+
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        parser.print_help()
+        parser.exit(1)
+
     return parser.parse_args(argv)
 
 

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -142,7 +142,6 @@ def upsert_stats(
                 """
                 CREATE TABLE IF NOT EXISTS {}.{} (
                     id BIGSERIAL PRIMARY KEY,
-                    run_ts TIMESTAMPTZ DEFAULT now(),
                     stats_date DATE NOT NULL,
                     cella TEXT NOT NULL,
                     partial_count INT,
@@ -162,14 +161,14 @@ def upsert_stats(
                 SET partial_count = EXCLUDED.partial_count,
                     full_count = EXCLUDED.full_count,
                     expected = EXCLUDED.expected
-                RETURNING id, run_ts
+                RETURNING id
                 """
             ).format(sql.Identifier(schema), sql.Identifier(table)),
             (stats_date, cella, partial_count, full_count, expected),
         )
-        row = cur.fetchone()
+        row_id = cur.fetchone()[0]
         conn.commit()
-        return row
+        return row_id
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +253,7 @@ def main() -> None:
             },
         )
 
-        row = upsert_stats(
+        record_id = upsert_stats(
             conn,
             schema,
             table,
@@ -264,7 +263,7 @@ def main() -> None:
             full_count,
             expected,
         )
-        print("DB record:", row)
+        print("DB record id:", record_id)
 
     conn.close()
 

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -100,9 +100,12 @@ def count_xls_rows(
         ) from exc
     if cella:
         df = df[df[cella_col] == cella]
-    # Dates in the reports use day-first formatting (e.g. 26.08.2025),
-    # so explicitly enable dayfirst parsing to avoid ambiguous warnings.
-    df[date_col] = pd.to_datetime(df[date_col], errors="coerce", dayfirst=True).dt.date
+    # Dates in the reports follow the format ``dd.mm.yyyy HH:MM:SS``
+    # (e.g. ``26.08.2025 13:30:58``). Parse with an explicit format to
+    # avoid ambiguous date warnings and then drop the time component.
+    df[date_col] = pd.to_datetime(
+        df[date_col], errors="coerce", format="%d.%m.%Y %H:%M:%S"
+    ).dt.date
     df = df[df[date_col] == stats_date]
     return df.groupby(cella_col).size()
 

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -64,6 +64,13 @@ def determine_stats_date(date_str: Optional[str], tz_name: Optional[str]) -> dat
     return today - timedelta(days=1)
 
 
+def resolve_path(path: str, base_dir: Optional[str]) -> str:
+    """Return an absolute path by prepending ``base_dir`` if provided."""
+    if os.path.isabs(path) or not base_dir:
+        return path
+    return os.path.join(base_dir, path)
+
+
 def count_xls_rows(
     path: str, date_col: str, cella_col: str, stats_date: date, cella: Optional[str]
 ) -> pd.Series:
@@ -166,10 +173,12 @@ def main() -> None:
     tz_name = getenv("TZ", "Europe/Moscow")
     stats_date = determine_stats_date(os.getenv("STATS_DATE"), tz_name)
 
-    partial_path = getenv("PARTIAL_XLS", "Частично.xls")
-    full_path = getenv("FULL_XLS", "Целиком.xls")
-    forecast_path = getenv(
-        "FORECAST_CSV", "Почасовой прогноз прихода заказов на склад.csv"
+    base_dir = os.getenv("DATA_DIR")
+    partial_path = resolve_path(getenv("PARTIAL_XLS", "Частично.xls"), base_dir)
+    full_path = resolve_path(getenv("FULL_XLS", "Целиком.xls"), base_dir)
+    forecast_path = resolve_path(
+        getenv("FORECAST_CSV", "Почасовой прогноз прихода заказов на склад.csv"),
+        base_dir,
     )
 
     date_col = getenv("DATE_COL", "Плановая дата поставки")
@@ -189,6 +198,7 @@ def main() -> None:
         "Parameters:",
         {
             "cella": cella,
+            "data_dir": base_dir,
             "partial": partial_path,
             "full": full_path,
             "forecast": forecast_path,

--- a/load_cella_stats_daily.py
+++ b/load_cella_stats_daily.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Daily Cella statistics loader.
+
+This script reads daily stats for a specific Cella from two XLS reports and one
+CSV forecast file and stores the aggregated result in PostgreSQL.
+
+See README or script docstring for usage details.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Optional
+
+import pandas as pd
+import psycopg2
+from psycopg2 import sql
+from dateutil import parser as date_parser, tz
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def normalize_colname(name: str) -> str:
+    """Normalize a column name for comparison.
+
+    Lower case, strip spaces, replace "ё" with "е".
+    """
+    return name.lower().replace("ё", "е").replace(" ", "")
+
+
+def find_expected_column(df: pd.DataFrame) -> str:
+    """Find the column representing expected quantity in the forecast file.
+
+    Exact match is performed on the normalized name. If no exact match is
+    found, a substring search for "ожид" is used.
+    """
+    normalized = {col: normalize_colname(col) for col in df.columns}
+    for col, norm in normalized.items():
+        if norm == "ожидается":
+            return col
+    for col, norm in normalized.items():
+        if "ожид" in norm:
+            return col
+    raise ValueError("Column 'Ожидается' not found in forecast file")
+
+
+def determine_stats_date(date_str: Optional[str], tz_name: Optional[str]) -> date:
+    """Determine the statistics date based on CLI argument and current day."""
+    if date_str:
+        return date_parser.isoparse(date_str).date()
+
+    tzinfo = tz.gettz(tz_name) if tz_name else None
+    today = datetime.now(tzinfo).date()
+    if today.weekday() == 0:  # Monday -> use previous Friday
+        return today - timedelta(days=3)
+    return today - timedelta(days=1)
+
+
+def count_xls_rows(path: str, date_col: str, cella_col: str, cella: str, stats_date: date) -> int:
+    """Count rows in an XLS file for given Cella and date."""
+    df = pd.read_excel(path, engine="xlrd")
+    df = df[df[cella_col] == cella]
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce").dt.date
+    return int((df[date_col] == stats_date).sum())
+
+
+def compute_expected(path: str, cella: str, cella_col: Optional[str]) -> Decimal:
+    """Compute expected value from CSV forecast file."""
+    df = pd.read_csv(path, sep=None, engine="python")
+    if cella_col:
+        df = df[df[cella_col] == cella]
+    if df.empty:
+        return Decimal("0")
+    col = find_expected_column(df)
+    values = pd.to_numeric(df[col], errors="coerce").dropna()
+    if values.empty:
+        return Decimal("0")
+    if len(values) == 1:
+        return Decimal(str(values.iloc[0]))
+    return Decimal(str(values.sum()))
+
+
+def upsert_stats(
+    conn: psycopg2.extensions.connection,
+    schema: str,
+    table: str,
+    stats_date: date,
+    cella: str,
+    partial_count: int,
+    full_count: int,
+    expected: Decimal,
+):
+    """Create tables if necessary and upsert statistics."""
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}" ).format(sql.Identifier(schema)))
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {}.{} (
+                    id BIGSERIAL PRIMARY KEY,
+                    run_ts TIMESTAMPTZ DEFAULT now(),
+                    stats_date DATE NOT NULL,
+                    cella TEXT NOT NULL,
+                    partial_count INT NOT NULL,
+                    full_count INT NOT NULL,
+                    expected NUMERIC(18,2) NOT NULL,
+                    UNIQUE (cella, stats_date)
+                )
+                """
+            ).format(sql.Identifier(schema), sql.Identifier(table))
+        )
+        cur.execute(
+            sql.SQL(
+                """
+                INSERT INTO {}.{} (stats_date, cella, partial_count, full_count, expected)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (cella, stats_date) DO UPDATE
+                SET partial_count = EXCLUDED.partial_count,
+                    full_count = EXCLUDED.full_count,
+                    expected = EXCLUDED.expected
+                RETURNING id, run_ts
+                """
+            ).format(sql.Identifier(schema), sql.Identifier(table)),
+            (stats_date, cella, partial_count, full_count, expected),
+        )
+        row = cur.fetchone()
+        conn.commit()
+        return row
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Load daily Cella statistics")
+    parser.add_argument("--cella", required=True, help="Cella value to filter")
+    parser.add_argument("--date", help="Stats date YYYY-MM-DD")
+    parser.add_argument("--partial", required=True, help="Path to 'Частично.xls'")
+    parser.add_argument("--full", required=True, help="Path to 'Целиком.xls'")
+    parser.add_argument(
+        "--forecast", required=True, help="Path to forecast CSV file"
+    )
+    parser.add_argument(
+        "--date-col",
+        default="Плановая дата поставки",
+        help="Column name with planned delivery date",
+    )
+    parser.add_argument(
+        "--cella-col", default="Cella", help="Column name with Cella in XLS"
+    )
+    parser.add_argument(
+        "--csv-cella-col",
+        help="Optional column name with Cella in forecast CSV",
+    )
+    parser.add_argument("--host", default=os.getenv("PGHOST"), help="DB host")
+    parser.add_argument(
+        "--port", type=int, default=int(os.getenv("PGPORT", 5432)), help="DB port"
+    )
+    parser.add_argument("--dbname", default=os.getenv("PGDATABASE"), help="DB name")
+    parser.add_argument("--user", default=os.getenv("PGUSER"), help="DB user")
+    parser.add_argument(
+        "--password", default=os.getenv("PGPASSWORD"), help="DB password"
+    )
+    parser.add_argument("--schema", default="REPORT", help="DB schema")
+    parser.add_argument(
+        "--table", default="execution-of-orders", help="DB table name"
+    )
+    parser.add_argument(
+        "--tz", default="Europe/Moscow", help="Timezone for date calculations"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+
+    stats_date = determine_stats_date(args.date, args.tz)
+    print(f"Stats date: {stats_date}")
+    print(f"Parameters: {args}")
+
+    partial_count = count_xls_rows(
+        args.partial, args.date_col, args.cella_col, args.cella, stats_date
+    )
+    full_count = count_xls_rows(
+        args.full, args.date_col, args.cella_col, args.cella, stats_date
+    )
+    expected = compute_expected(args.forecast, args.cella, args.csv_cella_col)
+
+    print(
+        "Computed metrics:",
+        {
+            "partial_count": partial_count,
+            "full_count": full_count,
+            "expected": float(expected),
+        },
+    )
+
+    conn = psycopg2.connect(
+        host=args.host,
+        port=args.port,
+        dbname=args.dbname,
+        user=args.user,
+        password=args.password,
+    )
+    row = upsert_stats(
+        conn,
+        args.schema,
+        args.table,
+        stats_date,
+        args.cella,
+        partial_count,
+        full_count,
+        expected,
+    )
+    conn.close()
+
+    print("DB record:", row)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+psycopg2-binary
+xlrd>=2.0.1
+python-dateutil


### PR DESCRIPTION
## Summary
- add `load_cella_stats_daily.py` to compute daily Cella metrics from two XLS reports and a forecast CSV and upsert results into PostgreSQL
- document usage in README

## Testing
- `python -m py_compile load_cella_stats_daily.py`
- `python load_cella_stats_daily.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68aed67429e88330bf577740b2302ef7